### PR TITLE
Add auth use cases to domain layer

### DIFF
--- a/app/src/main/java/edu/stanford/cardinalkit/common/Constants.kt
+++ b/app/src/main/java/edu/stanford/cardinalkit/common/Constants.kt
@@ -34,14 +34,21 @@ object Constants {
     const val SURVEYS_REF = "surveysRef"
     const val TASKS_REF = "tasksRef"
     const val TASKLOG_REF = "taskLogRef"
+
     const val SIGN_IN_REQUEST = "signInRequest"
     const val SIGN_UP_REQUEST = "signUpRequest"
+
     const val SURVEY_REPOSITORY = "surveyRepository"
+    const val SURVEYS_USE_CASES = "surveysUseCases"
+
     const val TASKS_REPOSITORY = "tasksRepository"
     const val TASKS_USE_CASES = "tasksUseCases"
+
     const val CONTACTS_REPOSITORY = "contactsRepository"
     const val CONTACTS_USE_CASES = "contactsUseCases"
-    const val SURVEYS_USE_CASES = "surveysUseCases"
+
+    const val AUTH_REPOSITORY = "authRepository"
+    const val AUTH_USE_CASES = "authUseCases"
 
     // Intents
     const val SURVEY_NAME = "edu.stanford.cardinalkit.SURVEY_NAME"

--- a/app/src/main/java/edu/stanford/cardinalkit/di/AppModule.kt
+++ b/app/src/main/java/edu/stanford/cardinalkit/di/AppModule.kt
@@ -28,6 +28,7 @@ import edu.stanford.cardinalkit.domain.repositories.AuthRepository
 import edu.stanford.cardinalkit.domain.repositories.ContactsRepository
 import edu.stanford.cardinalkit.domain.repositories.SurveyRepository
 import edu.stanford.cardinalkit.domain.repositories.TasksRepository
+import edu.stanford.cardinalkit.domain.use_cases.auth.*
 import edu.stanford.cardinalkit.domain.use_cases.tasks.GetTasks
 import edu.stanford.cardinalkit.domain.use_cases.tasks.TasksUseCases
 import edu.stanford.cardinalkit.domain.use_cases.contacts.ContactsUseCases
@@ -213,5 +214,18 @@ class AppModule {
         getTasks = GetTasks(repository),
         uploadTaskLog = UploadTaskLog(repository),
         getTaskLogs = GetTaskLogs(repository)
+    )
+
+    @Provides
+    @Named(Constants.AUTH_USE_CASES)
+    fun provideAuthUseCases(
+        repository: AuthRepository
+    ) = AuthUseCases(
+        signInWithEmail = SignInWithEmail(repository),
+        signUpWithEmail = SignUpWithEmail(repository),
+        oneTapSignIn = OneTapSignIn(repository),
+        signInWithGoogle = SignInWithGoogle(repository),
+        saveUser = SaveUser(repository),
+        getAuthStatus = GetAuthStatus(repository)
     )
 }

--- a/app/src/main/java/edu/stanford/cardinalkit/domain/use_cases/auth/AuthUseCases.kt
+++ b/app/src/main/java/edu/stanford/cardinalkit/domain/use_cases/auth/AuthUseCases.kt
@@ -1,0 +1,10 @@
+package edu.stanford.cardinalkit.domain.use_cases.auth
+
+data class AuthUseCases (
+    val signInWithEmail: SignInWithEmail,
+    val signUpWithEmail: SignUpWithEmail,
+    val oneTapSignIn: OneTapSignIn,
+    val signInWithGoogle: SignInWithGoogle,
+    val saveUser: SaveUser,
+    val getAuthStatus: GetAuthStatus
+)

--- a/app/src/main/java/edu/stanford/cardinalkit/domain/use_cases/auth/GetAuthStatus.kt
+++ b/app/src/main/java/edu/stanford/cardinalkit/domain/use_cases/auth/GetAuthStatus.kt
@@ -1,0 +1,9 @@
+package edu.stanford.cardinalkit.domain.use_cases.auth
+
+import edu.stanford.cardinalkit.domain.repositories.AuthRepository
+
+class GetAuthStatus(
+    private val repository: AuthRepository
+) {
+    operator fun invoke() = repository.getAuthStatus()
+}

--- a/app/src/main/java/edu/stanford/cardinalkit/domain/use_cases/auth/OneTapSignIn.kt
+++ b/app/src/main/java/edu/stanford/cardinalkit/domain/use_cases/auth/OneTapSignIn.kt
@@ -1,0 +1,9 @@
+package edu.stanford.cardinalkit.domain.use_cases.auth
+
+import edu.stanford.cardinalkit.domain.repositories.AuthRepository
+
+class OneTapSignIn(
+    private val repository: AuthRepository
+) {
+    suspend operator fun invoke() = repository.oneTapSignInWithGoogle()
+}

--- a/app/src/main/java/edu/stanford/cardinalkit/domain/use_cases/auth/SaveUser.kt
+++ b/app/src/main/java/edu/stanford/cardinalkit/domain/use_cases/auth/SaveUser.kt
@@ -1,0 +1,9 @@
+package edu.stanford.cardinalkit.domain.use_cases.auth
+
+import edu.stanford.cardinalkit.domain.repositories.AuthRepository
+
+class SaveUser(
+    private val repository: AuthRepository
+) {
+    suspend operator fun invoke() = repository.saveUser()
+}

--- a/app/src/main/java/edu/stanford/cardinalkit/domain/use_cases/auth/SignInWithEmail.kt
+++ b/app/src/main/java/edu/stanford/cardinalkit/domain/use_cases/auth/SignInWithEmail.kt
@@ -1,0 +1,12 @@
+package edu.stanford.cardinalkit.domain.use_cases.auth
+
+import edu.stanford.cardinalkit.domain.repositories.AuthRepository
+
+class SignInWithEmail(
+    private val repository: AuthRepository
+) {
+    suspend operator fun invoke(
+        email: String,
+        password: String
+    ) = repository.signIn(email, password)
+}

--- a/app/src/main/java/edu/stanford/cardinalkit/domain/use_cases/auth/SignInWithGoogle.kt
+++ b/app/src/main/java/edu/stanford/cardinalkit/domain/use_cases/auth/SignInWithGoogle.kt
@@ -1,0 +1,12 @@
+package edu.stanford.cardinalkit.domain.use_cases.auth
+
+import com.google.firebase.auth.AuthCredential
+import edu.stanford.cardinalkit.domain.repositories.AuthRepository
+
+class SignInWithGoogle(
+    private val repository: AuthRepository
+) {
+    suspend operator fun invoke(
+        googleCredential: AuthCredential
+    ) = repository.firebaseSignInWithGoogle(googleCredential)
+}

--- a/app/src/main/java/edu/stanford/cardinalkit/domain/use_cases/auth/SignUpWithEmail.kt
+++ b/app/src/main/java/edu/stanford/cardinalkit/domain/use_cases/auth/SignUpWithEmail.kt
@@ -1,0 +1,12 @@
+package edu.stanford.cardinalkit.domain.use_cases.auth
+
+import edu.stanford.cardinalkit.domain.repositories.AuthRepository
+
+class SignUpWithEmail (
+    private val repository: AuthRepository
+    ) {
+    suspend operator fun invoke(
+        email: String,
+        password: String
+    ) = repository.signUp(email, password)
+}

--- a/app/src/main/java/edu/stanford/cardinalkit/presentation/login/LoginScreen.kt
+++ b/app/src/main/java/edu/stanford/cardinalkit/presentation/login/LoginScreen.kt
@@ -256,17 +256,6 @@ fun LoginScreen(
 
     when(val signInResponse = viewModel.signInState.value) {
         is Response.Loading -> ProgressIndicator()
-        is Response.Success -> {
-            signInResponse.data?.let { isNewUser ->
-                if (isNewUser) {
-                    LaunchedEffect(isNewUser) {
-                        viewModel.saveUser()
-                    }
-                } else {
-                    navController.navigate(Screens.MainScreen.route)
-                }
-            }
-        }
         is Response.Error -> signInResponse.e?.let {
             Toast.makeText(context, it.message, Toast.LENGTH_SHORT).show()
         }
@@ -274,13 +263,6 @@ fun LoginScreen(
 
     when(val saveUserResponse = viewModel.saveUserState.value) {
         is Response.Loading -> ProgressIndicator()
-        is Response.Success -> {
-            saveUserResponse.data?.let { isUserCreated ->
-                if (isUserCreated) {
-                    navController.navigate(Screens.MainScreen.route)
-                }
-            }
-        }
         is Response.Error -> saveUserResponse.e?.let {
             Toast.makeText(context, it.message, Toast.LENGTH_SHORT).show()
         }

--- a/app/src/main/java/edu/stanford/cardinalkit/presentation/login/LoginViewModel.kt
+++ b/app/src/main/java/edu/stanford/cardinalkit/presentation/login/LoginViewModel.kt
@@ -9,15 +9,19 @@ import com.google.android.gms.auth.api.identity.BeginSignInResult
 import com.google.android.gms.auth.api.identity.SignInClient
 import com.google.firebase.auth.AuthCredential
 import dagger.hilt.android.lifecycle.HiltViewModel
+import edu.stanford.cardinalkit.common.Constants
 import edu.stanford.cardinalkit.domain.models.Response
 import edu.stanford.cardinalkit.domain.repositories.AuthRepository
+import edu.stanford.cardinalkit.domain.use_cases.auth.AuthUseCases
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import javax.inject.Inject
+import javax.inject.Named
 
 @HiltViewModel
 class LoginViewModel @Inject constructor(
-    private val repository: AuthRepository,
+    @Named(Constants.AUTH_USE_CASES)
+    private val useCases: AuthUseCases,
     val client: SignInClient
 ): ViewModel() {
     private val _oneTapSignInState = mutableStateOf<Response<BeginSignInResult>>(Response.Success(null))
@@ -31,7 +35,7 @@ class LoginViewModel @Inject constructor(
 
     fun signIn(email: String, password: String) {
         viewModelScope.launch {
-            repository.signIn(email, password).collect { result ->
+            useCases.signInWithEmail(email, password).collect { result ->
                 _signInState.value = result
             }
         }
@@ -39,7 +43,7 @@ class LoginViewModel @Inject constructor(
 
     fun oneTapSignIn() {
         viewModelScope.launch {
-            repository.oneTapSignInWithGoogle().collect { result ->
+            useCases.oneTapSignIn().collect { result ->
                 _oneTapSignInState.value = result
             }
         }
@@ -47,7 +51,7 @@ class LoginViewModel @Inject constructor(
 
     fun signInWithGoogle(googleCredential: AuthCredential) {
         viewModelScope.launch {
-            repository.firebaseSignInWithGoogle(googleCredential).collect { result ->
+            useCases.signInWithGoogle(googleCredential).collect { result ->
                 _signInState.value = result
             }
         }
@@ -55,14 +59,14 @@ class LoginViewModel @Inject constructor(
 
     fun saveUser() {
         viewModelScope.launch {
-            repository.saveUser().collect { result ->
+            useCases.saveUser().collect { result ->
                 _saveUserState.value = result
             }
         }
     }
 
     fun getAuthStatus() = liveData(Dispatchers.IO) {
-        repository.getAuthStatus().collect { result ->
+        useCases.getAuthStatus().collect { result ->
             emit(result)
         }
     }

--- a/app/src/main/java/edu/stanford/cardinalkit/presentation/register/RegisterScreen.kt
+++ b/app/src/main/java/edu/stanford/cardinalkit/presentation/register/RegisterScreen.kt
@@ -213,8 +213,14 @@ fun RegisterScreen(
 
     when(val signUpResponse = viewModel.signUpState.value) {
         is Response.Loading -> ProgressIndicator()
-        is Response.Success -> return
         is Response.Error -> signUpResponse.e?.let {
+            Toast.makeText(context, it.message, Toast.LENGTH_SHORT).show()
+        }
+    }
+
+    when(val saveUserResponse = viewModel.saveUserState.value) {
+        is Response.Loading -> ProgressIndicator()
+        is Response.Error -> saveUserResponse.e?.let {
             Toast.makeText(context, it.message, Toast.LENGTH_SHORT).show()
         }
     }

--- a/app/src/main/java/edu/stanford/cardinalkit/presentation/register/RegisterViewModel.kt
+++ b/app/src/main/java/edu/stanford/cardinalkit/presentation/register/RegisterViewModel.kt
@@ -22,11 +22,20 @@ class RegisterViewModel @Inject constructor(
     private val _signUpState = mutableStateOf<Response<Boolean>>(Response.Success(null))
     val signUpState: State<Response<Boolean>> = _signUpState
 
+    private val _saveUserState = mutableStateOf<Response<Boolean>>(Response.Success(null))
+    val saveUserState: State<Response<Boolean>> = _saveUserState
+
     fun signUp(email: String, password: String) {
         viewModelScope.launch {
             useCases.signUpWithEmail(email, password).collect() { result ->
                 _signUpState.value = result
             }
+        }
+    }
+
+    fun saveUser() = viewModelScope.launch {
+        useCases.saveUser().collect { response ->
+            _saveUserState.value = response
         }
     }
 }

--- a/app/src/main/java/edu/stanford/cardinalkit/presentation/register/RegisterViewModel.kt
+++ b/app/src/main/java/edu/stanford/cardinalkit/presentation/register/RegisterViewModel.kt
@@ -5,14 +5,18 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
+import edu.stanford.cardinalkit.common.Constants
 import edu.stanford.cardinalkit.domain.models.Response
 import edu.stanford.cardinalkit.domain.repositories.AuthRepository
+import edu.stanford.cardinalkit.domain.use_cases.auth.AuthUseCases
 import kotlinx.coroutines.launch
 import javax.inject.Inject
+import javax.inject.Named
 
 @HiltViewModel
 class RegisterViewModel @Inject constructor(
-    private val repository: AuthRepository
+    @Named(Constants.AUTH_USE_CASES)
+    private val useCases: AuthUseCases
 ): ViewModel() {
 
     private val _signUpState = mutableStateOf<Response<Boolean>>(Response.Success(null))
@@ -20,7 +24,7 @@ class RegisterViewModel @Inject constructor(
 
     fun signUp(email: String, password: String) {
         viewModelScope.launch {
-            repository.signUp(email, password).collect() { result ->
+            useCases.signUpWithEmail(email, password).collect() { result ->
                 _signUpState.value = result
             }
         }


### PR DESCRIPTION
- Adds use cases for authentication to domain layer
- Fixes issue where registering with email/password didn't create a user document in Firestore