### PR TITLE
Save task log after verified completion of survey

### DIFF
--- a/app/src/main/java/edu/stanford/cardinalkit/common/Constants.kt
+++ b/app/src/main/java/edu/stanford/cardinalkit/common/Constants.kt
@@ -55,5 +55,6 @@ object Constants {
 
     // Intents
     const val SURVEY_NAME = "edu.stanford.cardinalkit.SURVEY_NAME"
+    const val TASK_ID = "edu.stanford.cardinalkit.TASK_ID"
 
 }

--- a/app/src/main/java/edu/stanford/cardinalkit/presentation/tasks/components/TaskCard.kt
+++ b/app/src/main/java/edu/stanford/cardinalkit/presentation/tasks/components/TaskCard.kt
@@ -52,16 +52,12 @@ fun TaskCard(
         else -> completed = false
     }
 
-    fun launchSurvey(surveyName: String){
+    fun launchSurvey(surveyName: String, taskID: String){
         val intent = Intent(context, SurveyActivity::class.java).apply {
             putExtra(Constants.SURVEY_NAME, surveyName)
+            putExtra(Constants.TASK_ID, taskID)
         }
         context.startActivity(intent)
-    }
-
-    fun uploadTaskLog(id: String) {
-        val taskLog = CKTaskLog(id)
-        viewModel.uploadTaskLog(taskLog)
     }
 
     Card(
@@ -70,8 +66,7 @@ fun TaskCard(
             if(viewModel.currentDate.value == LocalDate.now()) {
                 when (category) {
                     CKTaskCategory.SURVEY -> {
-                        launchSurvey(uri)
-                        uploadTaskLog(id)
+                        launchSurvey(surveyName = uri, taskID = id)
                     }
                 }
             } else {


### PR DESCRIPTION
Previously task logs were saving before we had verification that the survey was successfully uploaded to the database. Now task logs will only save if the survey is verified to have been uploaded.