### PR TITLE
Allow contacts to be imported from Firestore

### DIFF
--- a/app/src/main/java/edu/stanford/cardinalkit/common/Config.kt
+++ b/app/src/main/java/edu/stanford/cardinalkit/common/Config.kt
@@ -2,8 +2,18 @@ package edu.stanford.cardinalkit.common
 
 object Config {
 
+    /**
+     * Names of files in the assets folder to
+     * extract tasks and items from.
+     */
     const val TASKS_FILE = "tasks.json"
     const val CONTACTS_FILE = "contacts.json"
+
+    /**
+     * Determines whether tasks and contacts should be retrieved
+     * from the database or files in the assets folder.
+     */
     const val REMOTE_TASKS = false
+    const val REMOTE_CONTACTS = false
 
 }

--- a/app/src/main/java/edu/stanford/cardinalkit/common/Constants.kt
+++ b/app/src/main/java/edu/stanford/cardinalkit/common/Constants.kt
@@ -12,6 +12,7 @@ object Constants {
     const val FIRESTORE_SURVEYS_COLLECTION = "surveys"
     const val FIRESTORE_TASKS_COLLECTION = "tasks"
     const val FIRESTORE_TASKLOG_COLLECTION = "tasklogs"
+    const val FIRESTORE_CONTACTS_COLLECTION = "contacts"
 
     // Screens
     const val MAIN_SCREEN = "Main"
@@ -35,6 +36,7 @@ object Constants {
     const val SURVEYS_REF = "surveysRef"
     const val TASKS_REF = "tasksRef"
     const val TASKLOG_REF = "taskLogRef"
+    const val CONTACTS_REF = "contactsRef"
 
     const val SIGN_IN_REQUEST = "signInRequest"
     const val SIGN_UP_REQUEST = "signUpRequest"

--- a/app/src/main/java/edu/stanford/cardinalkit/data/repositories/ContactsRepositoryImpl.kt
+++ b/app/src/main/java/edu/stanford/cardinalkit/data/repositories/ContactsRepositoryImpl.kt
@@ -1,38 +1,69 @@
 package edu.stanford.cardinalkit.data.repositories
 
 import android.content.Context
+import com.google.firebase.firestore.CollectionReference
 import com.google.gson.Gson
 import com.google.gson.JsonParseException
 import com.google.gson.reflect.TypeToken
 import edu.stanford.cardinalkit.common.Config
+import edu.stanford.cardinalkit.common.Constants
 import edu.stanford.cardinalkit.domain.models.Contact
 import edu.stanford.cardinalkit.domain.models.Response
+import edu.stanford.cardinalkit.domain.models.tasks.CKTask
 import edu.stanford.cardinalkit.domain.repositories.ContactsRepository
+import kotlinx.coroutines.channels.awaitClose
+import kotlinx.coroutines.flow.callbackFlow
+import kotlinx.coroutines.flow.flow
 import java.io.IOException
 import javax.inject.Inject
+import javax.inject.Named
 
 class ContactsRepositoryImpl @Inject constructor(
+    @Named(Constants.CONTACTS_REF)
+    private val contactsRef: CollectionReference?,
     private val context: Context
-    ) : ContactsRepository {
+) : ContactsRepository {
 
-    override fun getContacts(): Response<List<Contact>> {
-        lateinit var jsonString: String
+    override fun getContacts() =
+        if (Config.REMOTE_CONTACTS) {
+            callbackFlow {
+                contactsRef?.let {
+                    val snapshotListener =
+                        contactsRef.addSnapshotListener { snapshot, e ->
+                            val response = if (snapshot != null) {
+                                val contacts = snapshot.toObjects(Contact::class.java)
+                                Response.Success(contacts)
+                            } else {
+                                Response.Error(e)
+                            }
+                            trySend(response).isSuccess
+                        }
+                    awaitClose {
+                        snapshotListener.remove()
+                    }
+                }
+            }
+        } else {
+            flow {
+                lateinit var jsonString: String
 
-        // Load contact data from JSON file in assets
-        try {
-            jsonString = context.assets.open(Config.CONTACTS_FILE)
-                .bufferedReader().use { it.readText() }
-        } catch (e: IOException) {
-            return Response.Error(e)
+                // Load contact data from JSON file in assets
+                emit(Response.Loading)
+                try {
+                    jsonString = context.assets.open(Config.CONTACTS_FILE)
+                        .bufferedReader().use { it.readText() }
+                } catch (e: IOException) {
+                    emit(Response.Error(e))
+                }
+
+                // Deserialize JSON into a list of Contacts
+                try {
+                    val listContactsType = object : TypeToken<List<Contact>>() {}.type
+                    val contacts: List<Contact> = Gson().fromJson(jsonString, listContactsType)
+                    emit(Response.Success(contacts))
+                } catch (e: JsonParseException) {
+                    emit(Response.Error(e))
+                }
+            }
         }
-
-        // Deserialize JSON into a list of Contacts
-        return try {
-            val listContactsType = object : TypeToken<List<Contact>>() {}.type
-            val contacts: List<Contact> = Gson().fromJson(jsonString, listContactsType)
-            Response.Success(contacts)
-        } catch (e: JsonParseException){
-            Response.Error(e)
-        }
-    }
 }

--- a/app/src/main/java/edu/stanford/cardinalkit/di/AppModule.kt
+++ b/app/src/main/java/edu/stanford/cardinalkit/di/AppModule.kt
@@ -97,6 +97,20 @@ class AppModule {
     }
 
     @Provides
+    @Named(Constants.CONTACTS_REF)
+    fun provideContactsRef(
+        db: FirebaseFirestore
+    ): CollectionReference? {
+        val user = Firebase.auth.currentUser
+        user?.let {
+            return db.collection(
+                "${Constants.FIRESTORE_BASE_DOCUMENT}/${Constants.FIRESTORE_CONTACTS_COLLECTION}"
+            )
+        }
+        return null
+    }
+
+    @Provides
     fun provideOneTapClient(context: Context) = Identity.getSignInClient(context)
 
     @Provides
@@ -184,8 +198,10 @@ class AppModule {
     @Provides
     @Named(Constants.CONTACTS_REPOSITORY)
     fun provideContactsRepository(
+        @Named(Constants.CONTACTS_REF)
+        contactsRef: CollectionReference?,
         context: Context
-    ): ContactsRepository = ContactsRepositoryImpl(context)
+    ): ContactsRepository = ContactsRepositoryImpl(contactsRef, context)
 
     @Provides
     @Named(Constants.SURVEYS_USE_CASES)

--- a/app/src/main/java/edu/stanford/cardinalkit/domain/models/Contact.kt
+++ b/app/src/main/java/edu/stanford/cardinalkit/domain/models/Contact.kt
@@ -1,18 +1,20 @@
 package edu.stanford.cardinalkit.domain.models
 
+import java.util.*
+
 data class Contact(
-    var id: String,
-    var title: String,
-    var firstName: String,
-    var lastName: String,
-    var role: String,
-    var phoneNumber: String,
-    var smsNumber: String,
-    var description: String,
-    var email: String,
-    var streetAddress: String,
-    var city: String,
-    var state: String,
-    var country: String,
-    var postalCode: String
+    var id: String = UUID.randomUUID().toString(),
+    var title: String = "",
+    var firstName: String = "",
+    var lastName: String = "",
+    var role: String = "",
+    var phoneNumber: String = "",
+    var smsNumber: String = "",
+    var description: String = "",
+    var email: String = "",
+    var streetAddress: String = "",
+    var city: String = "",
+    var state: String = "",
+    var country: String = "",
+    var postalCode: String = ""
 )

--- a/app/src/main/java/edu/stanford/cardinalkit/domain/models/tasks/CKTask.kt
+++ b/app/src/main/java/edu/stanford/cardinalkit/domain/models/tasks/CKTask.kt
@@ -3,7 +3,7 @@ package edu.stanford.cardinalkit.domain.models.tasks
 import java.util.*
 
 data class CKTask(
-    val id: String = "",
+    val id: String = UUID.randomUUID().toString(),
     val title: String = "",
     val description: String = "",
     val context: CKTaskContext = CKTaskContext(),

--- a/app/src/main/java/edu/stanford/cardinalkit/domain/repositories/ContactsRepository.kt
+++ b/app/src/main/java/edu/stanford/cardinalkit/domain/repositories/ContactsRepository.kt
@@ -5,5 +5,5 @@ import edu.stanford.cardinalkit.domain.models.Response
 import kotlinx.coroutines.flow.Flow
 
 interface ContactsRepository {
-    fun getContacts(): Response<List<Contact>>
+    fun getContacts(): Flow<Response<List<Contact>>>
 }

--- a/app/src/main/java/edu/stanford/cardinalkit/domain/use_cases/contacts/GetContacts.kt
+++ b/app/src/main/java/edu/stanford/cardinalkit/domain/use_cases/contacts/GetContacts.kt
@@ -2,8 +2,8 @@ package edu.stanford.cardinalkit.domain.use_cases.contacts
 
 import edu.stanford.cardinalkit.domain.repositories.ContactsRepository
 
-class GetContacts (
+class GetContacts(
     private val repository: ContactsRepository
-    ) {
+) {
     operator fun invoke() = repository.getContacts()
 }

--- a/app/src/main/java/edu/stanford/cardinalkit/domain/use_cases/tasks/GetTasks.kt
+++ b/app/src/main/java/edu/stanford/cardinalkit/domain/use_cases/tasks/GetTasks.kt
@@ -2,8 +2,8 @@ package edu.stanford.cardinalkit.domain.use_cases.tasks
 
 import edu.stanford.cardinalkit.domain.repositories.TasksRepository
 
-class GetTasks  (
+class GetTasks(
     private val repository: TasksRepository
-    ){
+) {
     operator fun invoke() = repository.getTasks()
 }

--- a/app/src/main/java/edu/stanford/cardinalkit/presentation/contacts/ContactsViewModel.kt
+++ b/app/src/main/java/edu/stanford/cardinalkit/presentation/contacts/ContactsViewModel.kt
@@ -18,15 +18,16 @@ class ContactsViewModel @Inject constructor(
     @Named(Constants.CONTACTS_USE_CASES)
     private val useCases: ContactsUseCases
 ) : ViewModel() {
-
-    private val _contactsState = mutableStateOf<Response<List<Contact>>>(Response.Loading)
-    val contactsState: State<Response<List<Contact>>> = _contactsState
+    var contactsState = mutableStateOf<Response<List<Contact>>>(Response.Loading)
+        private set
 
     init {
         getContacts()
     }
 
     private fun getContacts() = viewModelScope.launch {
-        _contactsState.value = useCases.getContacts()
+        useCases.getContacts().collect { response ->
+            contactsState.value = response
+        }
     }
 }


### PR DESCRIPTION
Developers can choose to either import contacts from a JSON file in the assets folder or query contacts from Firestore.

Closes #57.