### PR TITLE
Add linting task to Gradle

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -48,6 +48,22 @@ android {
             excludes += '/META-INF/{AL2.0,LGPL2.1}'
         }
     }
+    lintOptions {
+        abortOnError false
+        textReport true
+        textOutput 'stderr'
+        checkReleaseBuilds true
+        warningsAsErrors false
+        explainIssues false
+        checkGeneratedSources false
+        checkDependencies true
+    }
+    applicationVariants.all { variant ->
+        variant.outputs.each { output ->
+            def lintTask = tasks["lint${variant.name.capitalize()}"]
+            assembleProvider.get().dependsOn.add(lintTask)
+        }
+    }
 }
 
 dependencies {


### PR DESCRIPTION
Adds linting as a Gradle task. Closes #3. 

Note: Does not currently enforce linting (abortOnError false) but will put results in the build output.