### PR TITLE
Updates Health Connect and fixes weight calculation

### DIFF
--- a/app/src/main/java/edu/stanford/cardinalkit/presentation/MainActivity.kt
+++ b/app/src/main/java/edu/stanford/cardinalkit/presentation/MainActivity.kt
@@ -9,6 +9,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
 import androidx.core.view.WindowCompat
+import androidx.health.connect.client.PermissionController
 import androidx.lifecycle.lifecycleScope
 import com.google.accompanist.navigation.animation.rememberAnimatedNavController
 import dagger.hilt.android.AndroidEntryPoint
@@ -42,9 +43,7 @@ class MainActivity : AppCompatActivity() {
          * if not already provided.
          */
         val requestPermissionsActivityContract =
-            healthViewModel.healthConnectManager.healthConnectClient
-                .permissionController
-                .createRequestPermissionActivityContract()
+            PermissionController.createRequestPermissionResultContract()
 
         val requestPermissions =
             registerForActivityResult(requestPermissionsActivityContract) { granted ->

--- a/app/src/main/java/edu/stanford/cardinalkit/presentation/health/HealthViewModel.kt
+++ b/app/src/main/java/edu/stanford/cardinalkit/presentation/health/HealthViewModel.kt
@@ -49,9 +49,12 @@ class HealthViewModel @Inject constructor(
         }
     }
 
+    /**
+     * Gets the average weight over the past 7 days
+     */
     fun getWeeklyAverageWeight() = viewModelScope.launch {
-        val startOfWeek = LocalDate.now().atStartOfDay(ZoneId.systemDefault()).toInstant()
-        val endOfWeek = startOfWeek.plus(7, ChronoUnit.DAYS)
+        val endOfWeek = Instant.now()
+        val startOfWeek = endOfWeek.minus(7, ChronoUnit.DAYS)
 
         if (permissionsGranted.value) {
             weeklyAverageWeight.value = healthConnectManager.getAverageWeight(

--- a/app/src/main/java/edu/stanford/cardinalkit/presentation/home/components/WeightCard.kt
+++ b/app/src/main/java/edu/stanford/cardinalkit/presentation/home/components/WeightCard.kt
@@ -18,13 +18,16 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.hilt.navigation.compose.hiltViewModel
 import edu.stanford.cardinalkit.presentation.health.HealthViewModel
+import kotlin.math.roundToInt
 
 @Composable
 fun WeightCard(
     viewModel: HealthViewModel = hiltViewModel()
 ) {
     viewModel.getWeeklyAverageWeight()
-    val pounds = viewModel.weeklyAverageWeight.value?.inPounds?.toInt().toString() + " lbs"
+    val avgWeightInPounds = viewModel.weeklyAverageWeight.value?.inPounds?.roundToInt()
+    var avgWeightString = "-"
+    if (avgWeightInPounds != null) avgWeightString = "$avgWeightInPounds lbs"
 
     Card(
         modifier = Modifier
@@ -48,12 +51,12 @@ fun WeightCard(
                 color = MaterialTheme.colorScheme.onSecondary
             )
             Text(
-                text = pounds,
+                text = avgWeightString,
                 fontSize = 40.sp,
                 color = MaterialTheme.colorScheme.onSecondary
             )
             Text(
-                text = "Average Weekly",
+                text = "7-day average",
                 fontSize = 15.sp,
                 color = MaterialTheme.colorScheme.onSecondary
             )

--- a/build.gradle
+++ b/build.gradle
@@ -15,7 +15,7 @@ buildscript {
         play_services_auth_version = "20.3.0"
         accompanist_version = "0.24.10-beta"
         coil_compose_version = "2.1.0"
-        health_connect_version = '1.0.0-alpha04'
+        health_connect_version = '1.0.0-alpha07'
         android_fhir_version = '0.1.0-beta05'
         spotless_version = '6.10.0'
     }


### PR DESCRIPTION
<!--

This source file is part of the CardinalKit open-source project

SPDX-FileCopyrightText: 2022 CardinalKit and the project authors (see CONTRIBUTORS.md)

SPDX-License-Identifier: MIT

-->

# Updates Health Connect and fixes weight calculation

## :recycle: Current situation & Problem
- Health Connect needs to be updated with adjustments for API changes.
- Weight card is not properly calculating the average weight over the past 7 days.

## :bulb: Proposed solution
- Updates Health Connect to 1.0.0-alpha07 and addresses API change of `PermissionController.createRequestPermissionActivityContract` as a static method instead of an instance method.
- Fixes the function that calculates the average weight over the past 7 days.

### Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/CardinalKit/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/CardinalKit/.github/blob/main/CONTRIBUTING.md):
- [X] I agree to follow the [Code of Conduct](https://github.com/CardinalKit/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/CardinalKit/.github/blob/main/CONTRIBUTING.md).