### PR TITLE
Migrate to Jetpack Compose BOM

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -97,13 +97,13 @@ dependencies {
     implementation "io.coil-kt:coil-compose:$coil_compose_version"
 
     //Compose
-    implementation "androidx.compose.ui:ui:$compose_version"
-    implementation "androidx.compose.material3:material3:1.0.0-beta01"
-    implementation "androidx.compose.material3:material3-window-size-class:1.0.0-beta01"
-    implementation "androidx.compose.ui:ui-tooling-preview:$compose_version"
-    implementation "androidx.compose.runtime:runtime-livedata:$compose_version"
-    implementation "androidx.compose.material:material-icons-extended:$compose_version"
-    implementation "androidx.compose.ui:ui-viewbinding:$compose_version"
+    implementation platform("androidx.compose:compose-bom:$compose_bom_version")
+    implementation "androidx.compose.material3:material3"
+    implementation "androidx.compose.material3:material3-window-size-class"
+    implementation "androidx.compose.ui:ui-tooling-preview"
+    implementation "androidx.compose.runtime:runtime-livedata"
+    implementation "androidx.compose.material:material-icons-extended"
+    implementation "androidx.compose.ui:ui-viewbinding"
 
     //AndroidX
     implementation "androidx.core:core-ktx:1.8.0"
@@ -124,12 +124,11 @@ dependencies {
     testImplementation "com.google.truth:truth:1.1.3"
     androidTestImplementation "androidx.test.ext:junit:1.1.3"
     androidTestImplementation "androidx.test.espresso:espresso-core:3.4.0"
-    androidTestImplementation "androidx.compose.ui:ui-test-junit4:$compose_version"
-    debugImplementation "androidx.compose.ui:ui-tooling:1.2.1"
-    debugImplementation "androidx.compose.ui:ui-test-manifest:$compose_version"
+    androidTestImplementation "androidx.compose.ui:ui-test-junit4:1.3.0"
+    debugImplementation "androidx.compose.ui:ui-tooling"
+    debugImplementation "androidx.compose.ui:ui-test-manifest"
 
     //Preview feature JetPack Compose dependency
-    debugImplementation "androidx.compose.ui:ui-tooling:1.2.1"
     implementation "androidx.compose.ui:ui-tooling-preview:1.2.1"
 
     //Splash Screen Dependency

--- a/app/src/main/java/edu/stanford/cardinalkit/presentation/surveys/SurveyActivity.kt
+++ b/app/src/main/java/edu/stanford/cardinalkit/presentation/surveys/SurveyActivity.kt
@@ -119,7 +119,7 @@ class SurveyActivity : AppCompatActivity() {
     private fun submitSurvey() {
         // Get the survey results from QuestionnaireFragment and upload to cloud
         val fragment = supportFragmentManager.findFragmentById(R.id.fragment_container_view)
-                as QuestionnaireFragment
+            as QuestionnaireFragment
         val questionnaireResponse = fragment.getQuestionnaireResponse()
         surveyName?.let { surveyViewModel.uploadSurveyResult(it, questionnaireResponse) }
     }

--- a/build.gradle
+++ b/build.gradle
@@ -1,14 +1,15 @@
 buildscript {
     ext {
         gradle_version = '7.2.2'
-        kotlin_version = "1.7.10"
+        kotlin_version = "1.7.20"
         google_services_version = "4.3.10"
         hilt_version = "2.43.2"
         core_version = "1.8.0"
         appcompat_version = "1.5.0"
         live_data_version = "2.5.1"
         material_version = "1.6.1"
-        compose_version = "1.3.0-beta01"
+        compose_version = "1.3.2"
+        compose_bom_version = "2022.10.00"
         hilt_navigation_compose_version = "1.0.0"
         firebase_bom_version = "30.1.0"
         play_services_version = "1.6.2"
@@ -23,6 +24,9 @@ buildscript {
         classpath "com.google.gms:google-services:$google_services_version"
         classpath "com.google.dagger:hilt-android-gradle-plugin:$hilt_version"
         classpath "com.diffplug.spotless:spotless-plugin-gradle:$spotless_version"
+    }
+    repositories {
+        google()
     }
 }// Top-level build file where you can add configuration options common to all sub-projects/modules.
 plugins {


### PR DESCRIPTION
<!--

This source file is part of the CardinalKit open-source project

SPDX-FileCopyrightText: 2022 CardinalKit and the project authors (see CONTRIBUTORS.md)

SPDX-License-Identifier: MIT

-->

# Migrate to Jetpack Compose BOM

## :recycle: Current situation & Problem
- Jetpack Compose dependencies are out of date

## :bulb: Proposed solution
- Migrates to the new stable release of Jetpack Compose, using the BOM: https://android-developers.googleblog.com/2022/10/whats-new-in-jetpack-compose.html

### Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/CardinalKit/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/CardinalKit/.github/blob/main/CONTRIBUTING.md):
- [X] I agree to follow the [Code of Conduct](https://github.com/CardinalKit/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/CardinalKit/.github/blob/main/CONTRIBUTING.md).

