### PR TITLE
Make home screen cards localizable

### DIFF
--- a/app/src/main/java/edu/stanford/cardinalkit/presentation/home/components/LearnMoreCard.kt
+++ b/app/src/main/java/edu/stanford/cardinalkit/presentation/home/components/LearnMoreCard.kt
@@ -16,10 +16,12 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.core.os.bundleOf
+import edu.stanford.cardinalkit.R
 
 @OptIn(ExperimentalMaterialApi::class)
 @Composable
@@ -28,7 +30,7 @@ fun LearnMoreCard() {
     Card(
         onClick = {
             val intent = Intent(Intent.ACTION_VIEW).apply {
-                data = Uri.parse("https://cardinalkit.sites.stanford.edu/")
+                data = Uri.parse("https://cardinalkit.stanford.edu/")
             }
             context.startActivity(intent, bundleOf())
         },
@@ -44,19 +46,19 @@ fun LearnMoreCard() {
                 .fillMaxWidth()
         ) {
             Text(
-                text = "Customize Your App",
+                text = stringResource(R.string.learn_more_card_header),
                 color = MaterialTheme.colorScheme.onPrimaryContainer,
                 fontWeight = FontWeight.SemiBold,
                 modifier = Modifier.padding(bottom = 5.dp),
                 fontSize = 20.sp
             )
             Text(
-                text = "This is a template app that you can customize to create your own digital health experience.",
+                text = stringResource(R.string.learn_more_card_text),
                 color = MaterialTheme.colorScheme.onPrimaryContainer
             )
             Spacer(modifier = Modifier.height(40.dp))
             Text(
-                text = "Learn how at cardinalkit.org",
+                text = stringResource(R.string.learn_more_card_footer),
                 color = MaterialTheme.colorScheme.onPrimaryContainer,
                 fontWeight = FontWeight.SemiBold
             )

--- a/app/src/main/java/edu/stanford/cardinalkit/presentation/home/components/StepsCard.kt
+++ b/app/src/main/java/edu/stanford/cardinalkit/presentation/home/components/StepsCard.kt
@@ -14,9 +14,11 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.hilt.navigation.compose.hiltViewModel
+import edu.stanford.cardinalkit.R
 import edu.stanford.cardinalkit.presentation.health.HealthViewModel
 
 @Composable
@@ -41,7 +43,7 @@ fun StepsCard(
 
         ) {
             Text(
-                text = "Steps",
+                text = stringResource(R.string.steps_card_header),
                 fontSize = 25.sp,
                 color = MaterialTheme.colorScheme.onSecondary
             )
@@ -51,7 +53,7 @@ fun StepsCard(
                 color = MaterialTheme.colorScheme.onSecondary
             )
             Text(
-                text = "Total Today",
+                text = stringResource(R.string.steps_card_total_today),
                 fontSize = 15.sp,
                 color = MaterialTheme.colorScheme.onSecondary
             )

--- a/app/src/main/java/edu/stanford/cardinalkit/presentation/home/components/WeightCard.kt
+++ b/app/src/main/java/edu/stanford/cardinalkit/presentation/home/components/WeightCard.kt
@@ -14,20 +14,33 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.hilt.navigation.compose.hiltViewModel
+import edu.stanford.cardinalkit.R
 import edu.stanford.cardinalkit.presentation.health.HealthViewModel
 import kotlin.math.roundToInt
 
 @Composable
 fun WeightCard(
-    viewModel: HealthViewModel = hiltViewModel()
+    viewModel: HealthViewModel = hiltViewModel(),
+    useMetricUnits: Boolean = true
 ) {
     viewModel.getWeeklyAverageWeight()
-    val avgWeightInPounds = viewModel.weeklyAverageWeight.value?.inPounds?.roundToInt()
+
     var avgWeightString = "-"
-    if (avgWeightInPounds != null) avgWeightString = "$avgWeightInPounds lbs"
+    val avgWeight = viewModel.weeklyAverageWeight.value
+
+    if (useMetricUnits) {
+        avgWeight?.inKilograms?.roundToInt().let {
+            avgWeightString = "$it kg"
+        }
+    } else {
+        avgWeight?.inPounds?.roundToInt().let {
+            avgWeightString = "$it lbs"
+        }
+    }
 
     Card(
         modifier = Modifier
@@ -46,7 +59,7 @@ fun WeightCard(
 
         ) {
             Text(
-                text = "Weight",
+                text = stringResource(R.string.weight_card_header),
                 fontSize = 25.sp,
                 color = MaterialTheme.colorScheme.onSecondary
             )
@@ -56,7 +69,7 @@ fun WeightCard(
                 color = MaterialTheme.colorScheme.onSecondary
             )
             Text(
-                text = "7-day average",
+                text = stringResource(R.string.weight_card_7_day_average),
                 fontSize = 15.sp,
                 color = MaterialTheme.colorScheme.onSecondary
             )

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -97,4 +97,15 @@
     <string name="email_and_password_empty">Please enter an email address and password.</string>
     <string name="required_field_empty">All required fields must be completed.</string>
     <string name="passwords_unmatched">Passwords must match.</string>
+
+    <!-- Home Screen Cards -->
+    <string name="steps_card_header">Steps</string>
+    <string name="steps_card_total_today">Total Today</string>
+
+    <string name="weight_card_header">Weight</string>
+    <string name="weight_card_7_day_average">7-day-average</string>
+
+    <string name="learn_more_card_header">Customize Your App</string>
+    <string name="learn_more_card_text">This is a template app that you can customize to create your own digital health experience.</string>
+    <string name="learn_more_card_footer">Learn how at cardinalkit.org</string>
 </resources>


### PR DESCRIPTION
<!--

This source file is part of the CardinalKit open-source project

SPDX-FileCopyrightText: 2022 CardinalKit and the project authors (see CONTRIBUTORS.md)

SPDX-License-Identifier: MIT

-->

# Make home screen cards localizable

## :recycle: Current situation & Problem
Cards on the home screen are currently not localizable.

## :bulb: Proposed solution
- Makes all strings on home screen cards localizable.
- Allows weight card to display in imperial or metric.

### Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/CardinalKit/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/CardinalKit/.github/blob/main/CONTRIBUTING.md):
- [X] I agree to follow the [Code of Conduct](https://github.com/CardinalKit/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/CardinalKit/.github/blob/main/CONTRIBUTING.md).

